### PR TITLE
Fix question loading for static hosting

### DIFF
--- a/script.js
+++ b/script.js
@@ -14,8 +14,14 @@ checkReady();
 
 async function loadQuestions() {
   try {
-    const base = window.location.origin === 'null' ? 'http://localhost:3000' : '';
-    const res = await fetch(base + '/questions');
+    let res;
+    try {
+      res = await fetch('questions.json');
+      if (!res.ok) throw new Error('Status ' + res.status);
+    } catch {
+      const base = window.location.origin === 'null' ? 'http://localhost:3000' : '';
+      res = await fetch(base + '/questions');
+    }
     questionDB = await res.json();
     questions = questionDB.part1.map(q => ({ ...q, part: "1", explanationType: 'staged' }));
     dataLoaded = true;


### PR DESCRIPTION
## Summary
- Load questions from `questions.json` with a fallback to the `/questions` endpoint

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f746ed948832595db4e007c5b8782