### PR TITLE
Fix math rendering and part progression

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <title>Teacher Marking Study</title>
   <link rel="stylesheet" href="styles.css" />
+  <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </head>
 <body>
   <div id="intro">


### PR DESCRIPTION
## Summary
- Load MathJax and invoke typesetting so questions and explanations display math properly.
- Fix study flow by showing Part 1 summary before finalizing and allow starting Part 2.
- Display AI marks and confidence from dataset by loading Part 1 questions directly from CSV instead of simulating.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f7b16f89c8325acff1de8d14c2561