### PR TITLE
style: enhance CTA layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -220,8 +220,10 @@ function renderQuestion() {
   typeset(qContainer);
 
   ctaContainer.innerHTML = `
-    <button id="self-mark">Mark Myself</button>
-    <button id="ai-mark">Use AI</button>
+    <div class="action-card">
+      <button id="self-mark" class="primary-button">Mark Myself</button>
+      <button id="ai-mark" class="secondary-button">Use AI</button>
+    </div>
   `;
   explanationDiv.innerHTML = "";
   explanationDiv.classList.add("hidden");

--- a/styles.css
+++ b/styles.css
@@ -28,3 +28,32 @@ body { font-family: Arial, sans-serif; margin: 2rem; }
   white-space: pre-wrap;
   max-width: 100%;
 }
+
+.action-card {
+  background-color: #f9f9f9;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.5rem;
+}
+
+.action-card button {
+  padding: 0.75rem;
+  font-size: 1rem;
+  border: none;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  width: 100%;
+}
+
+.action-card .primary-button {
+  background-color: #007bff;
+  color: #fff;
+}
+
+.action-card .secondary-button {
+  background-color: #e0e0e0;
+  color: #333;
+}


### PR DESCRIPTION
## Summary
- Wrap question CTA buttons in an action-card container
- Style action-card and buttons for better spacing and visual hierarchy

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1765126e083259e7bb7fdfb1cd04c