### PR TITLE
Fix lingering controls when transitioning to Part 2b

### DIFF
--- a/script.js
+++ b/script.js
@@ -209,7 +209,7 @@ function renderQuestion() {
     goldMark: q.correctMark ?? q.goldMark,
     actions: [],
   };
-
+  qContainer.classList.remove("hidden");
   qContainer.innerHTML = `
     <h2>Question ${q.id} (Part ${q.part})</h2>
     <p><strong>Question:</strong> ${formatText(q.question)}</p>
@@ -530,6 +530,7 @@ function showPartSummary(part, final = false) {
 }
 
 function showPart2bPrompt() {
+  mainDiv.classList.add("hidden");
   qContainer.classList.add("hidden");
   explanationDiv.classList.add("hidden");
   summaryDiv.innerHTML = `<h2>Part 2a Complete</h2>`;


### PR DESCRIPTION
## Summary
- Hide question and action controls while displaying the Part 2b prompt to remove leftover buttons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a17666ff6483259810a0fc9b7e1e4a