### PR TITLE
Improve action button styling and add scrollable sections

### DIFF
--- a/script.js
+++ b/script.js
@@ -223,8 +223,9 @@ function renderQuestion() {
 
   ctaContainer.innerHTML = `
     <div class="action-card">
-      <button id="self-mark" class="primary-button">Mark Myself</button>
-      <button id="ai-mark" class="secondary-button">Use AI</button>
+      <p>Choose how you want to mark this question</p>
+      <button id="self-mark">Mark Myself</button>
+      <button id="ai-mark">Use AI</button>
     </div>
   `;
   explanationDiv.innerHTML = "";

--- a/styles.css
+++ b/styles.css
@@ -9,6 +9,8 @@ body { font-family: Arial, sans-serif; margin: 2rem; }
   flex: 0 0 60%;
   max-width: 60%;
   margin-top: 1rem;
+  max-height: 80vh;
+  overflow-y: auto;
 }
 #action-container {
   flex: 0 0 40%;
@@ -16,6 +18,8 @@ body { font-family: Arial, sans-serif; margin: 2rem; }
   margin-top: 1rem;
   display: flex;
   flex-direction: column;
+  max-height: 80vh;
+  overflow-y: auto;
 }
 #explanation-container {
   margin-top: 1rem;
@@ -35,25 +39,11 @@ body { font-family: Arial, sans-serif; margin: 2rem; }
   border-radius: 0.5rem;
   display: flex;
   flex-direction: column;
-  align-items: stretch;
+  align-items: flex-start;
   gap: 0.5rem;
 }
 
 .action-card button {
-  padding: 0.75rem;
   font-size: 1rem;
-  border: none;
-  border-radius: 0.25rem;
   cursor: pointer;
-  width: 100%;
-}
-
-.action-card .primary-button {
-  background-color: #007bff;
-  color: #fff;
-}
-
-.action-card .secondary-button {
-  background-color: #e0e0e0;
-  color: #333;
 }


### PR DESCRIPTION
## Summary
- Add instruction text and unify action buttons in question view
- Make question and action panels separately scrollable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1b93b91508325a1b565f1236d6375