### PR TITLE
Improve action button styling and add scrollable sections

### DIFF
--- a/script.js
+++ b/script.js
@@ -162,6 +162,11 @@ const explanationDiv = document.getElementById("explanation-container");
 const summaryDiv = document.getElementById("summary");
 const variantPicker = document.getElementById("variant-picker");
 
+function setActionCard(innerHtml) {
+  ctaContainer.innerHTML = `<div class="action-card">${innerHtml}</div>`;
+  typeset(ctaContainer);
+}
+
 function typeset(element) {
   if (window.MathJax?.typesetPromise) {
     MathJax.typesetPromise(element ? [element] : undefined);
@@ -221,12 +226,11 @@ function renderQuestion() {
   `;
   typeset(qContainer);
 
-  ctaContainer.innerHTML = `
-    <div class="action-card">
-      <button id="self-mark" class="primary-button">Mark Myself</button>
-      <button id="ai-mark" class="secondary-button">Use AI</button>
-    </div>
-  `;
+  setActionCard(`
+      <p>Choose how you want to mark this question</p>
+      <button id="self-mark">Mark Myself</button>
+      <button id="ai-mark">Use AI</button>
+    `);
   explanationDiv.innerHTML = "";
   explanationDiv.classList.add("hidden");
   mainDiv.classList.remove("hidden");
@@ -254,11 +258,11 @@ function goToNextQuestion() {
 }
 
 function handleSelfMark(q) {
-  ctaContainer.innerHTML = `
+  setActionCard(`
     <p>Enter your mark:</p>
     <input type="number" id="mark-input" min="0" max="${q.maxMarks}" />
     <button id="submit-mark">Submit</button>
-  `;
+  `);
   const markInput = document.getElementById("mark-input");
 
   document.getElementById("submit-mark").onclick = () => {
@@ -272,13 +276,13 @@ function handleSelfMark(q) {
       const ai = getAi(q);
       currentRecord.aiMark = ai.aiMark;
       currentRecord.aiConfidence = ai.confidence;
-      ctaContainer.innerHTML = `
+      setActionCard(`
           <p><strong>AI Mark:</strong> ${ai.aiMark} / ${q.maxMarks}</p>
           <p><strong>Confidence:</strong> ${ai.confidence}</p>
           <button id="view-staged">View Staged Explanation</button>
           <button id="view-summary">View Summary Explanation</button>
           <button id="next-q">Next</button>
-          `;
+          `);
       explanationDiv.innerHTML = `<div id="staged-exp" class="hidden"></div><div id="summary-exp" class="hidden"></div>`;
       explanationDiv.classList.add("hidden");
       const stagedBtn = document.getElementById("view-staged");
@@ -364,7 +368,7 @@ function handleAIMark(q) {
   currentRecord.aiMark = ai.aiMark;
   currentRecord.aiConfidence = ai.confidence;
 
-  ctaContainer.innerHTML = `
+  setActionCard(`
     <p><strong>AI Mark:</strong> ${ai.aiMark} / ${q.maxMarks}</p>
     <p><strong>Confidence:</strong> ${ai.confidence}</p>
     <label>Final mark: <input type="number" id="final-mark" min="0" max="${q.maxMarks}" value="${ai.aiMark}" /></label>
@@ -375,8 +379,7 @@ function handleAIMark(q) {
         : `<button id="view-exp">View Explanation</button>`
     }
     <button id="submit-mark">Submit</button>
-    `;
-  typeset(ctaContainer);
+    `);
 
   if (q.part === "1") {
     explanationDiv.innerHTML = `<div id="staged-exp" class="hidden"></div><div id="summary-exp" class="hidden"></div>`;

--- a/styles.css
+++ b/styles.css
@@ -9,6 +9,8 @@ body { font-family: Arial, sans-serif; margin: 2rem; }
   flex: 0 0 60%;
   max-width: 60%;
   margin-top: 1rem;
+  max-height: 80vh;
+  overflow-y: auto;
 }
 #action-container {
   flex: 0 0 40%;
@@ -16,6 +18,8 @@ body { font-family: Arial, sans-serif; margin: 2rem; }
   margin-top: 1rem;
   display: flex;
   flex-direction: column;
+  max-height: 80vh;
+  overflow-y: auto;
 }
 #explanation-container {
   margin-top: 1rem;
@@ -35,25 +39,11 @@ body { font-family: Arial, sans-serif; margin: 2rem; }
   border-radius: 0.5rem;
   display: flex;
   flex-direction: column;
-  align-items: stretch;
+  align-items: flex-start;
   gap: 0.5rem;
 }
 
 .action-card button {
-  padding: 0.75rem;
   font-size: 1rem;
-  border: none;
-  border-radius: 0.25rem;
   cursor: pointer;
-  width: 100%;
-}
-
-.action-card .primary-button {
-  background-color: #007bff;
-  color: #fff;
-}
-
-.action-card .secondary-button {
-  background-color: #e0e0e0;
-  color: #333;
 }


### PR DESCRIPTION
## Summary
- Add instruction text and unify action buttons in question view
- Make question and action panels separately scrollable
- Ensure all CTA states share consistent action-card styling across L1–L4 variants

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1b93b91508325a1b565f1236d6375